### PR TITLE
Doughnut Paper Audit Updates

### DIFF
--- a/CENNZnet_format.md
+++ b/CENNZnet_format.md
@@ -33,13 +33,15 @@ A CENNZnut contains:
 **Note:** *Subject to change*
 
 * 1 byte
-    * `module_count`
+    * `module_count` = value + 1
+    * Range = [1, 256]
 * Modules list
     * 1 byte
         * 1 bit
             * `has_block_cooldown` flag
         * 7 bits
-            * `method_count`
+            * `method_count` = value + 1
+            * Range = [1, 128]
     * 32 bytes
         * `module_name`
         * String
@@ -62,12 +64,11 @@ A CENNZnut contains:
                 * `block_cooldown`
         * If `has_pact` is set
             * 1 byte
-                * `pact_length`
-                * `pact_length` = byte_value + 1
+                * `pact_length` = value + 1
             * `pact_length` bytes
                 * `pact`
 * 1 byte
-    * `contract_count`
+    * `contract_count` = value
 * Contracts list
     * 1 byte
         * 1 bit
@@ -82,11 +83,11 @@ A CENNZnut contains:
 
 ### Decode Steps
 
-1. Read the first byte, as `module_count`
+1. Read the first byte, as `module_count` and increment it by 1
 2. Begin reading module list items
     1. Read the first byte
         - Read the first bit as `has_block_cooldown` Boolean
-        - Read the last 7 bits as `method_count`
+        - Read the last 7 bits as `method_count` and increment it by 1
     2. Read 32 bytes as `module_name`
     3. If `has_block_cooldown`
         - Read 4 bytes as `block_cooldown`
@@ -112,6 +113,23 @@ A CENNZnut contains:
     3. If `has_block_cooldown`
         - Read 4 bytes as `block_cooldown`
     4. Repeat until `contract_count` matches iterations
+
+### Smart Contracts
+
+Any CENNZnut with smart contract permissions must also assign runtime module permissions for the contracts module:
+```json
+{
+    "modules": {
+        "contracts": {
+            "call": {}
+        }
+    },
+    "contracts": {
+        "d0a98...56d7e9c": {},
+        "b2150...2f40a21": {},
+    }
+}
+```
 
 ### Wildcards
 

--- a/CENNZnet_format.md
+++ b/CENNZnet_format.md
@@ -4,9 +4,17 @@
 
 This document outlines the format of the CENNZnet Doughnut Permission Domain.
 
+## Encoding
+
+A CENNZnut is little-endian binary encoded.
+
+Both bit and byte order are little-endian (eg, `0b10000000_00000000 = 1_u16`).
+
 ## Structure
 
-The domain is binary encoded. It contains a version definition, and a permissions definition.
+A CENNZnut contains:
+* a `VERSION` definition
+* a `PERMISSIONS` definition
 
 ```
 <VERSION><PERMISSIONS>
@@ -16,7 +24,6 @@ The domain is binary encoded. It contains a version definition, and a permission
 
 * 10 bits
     * Version number
-    * LE unsigned integer
 * 6 bits
     * Reserved/unused
 
@@ -27,21 +34,18 @@ The domain is binary encoded. It contains a version definition, and a permission
 
 * 1 byte
     * `module_count`
-    * LE unsigned integer
 * Modules list
     * 1 byte
         * 1 bit
             * `has_block_cooldown` flag
         * 7 bits
             * `method_count`
-            * LE unsigned integer
     * 32 bytes
         * `module_name`
         * String
     * If `has_block_cooldown`
         * 4 bytes
             * `block_cooldown`
-            * LE unsigned integer
     * Methods list
         * 1 byte
             * 1 bit
@@ -56,17 +60,14 @@ The domain is binary encoded. It contains a version definition, and a permission
         * If `block_cooldown` is set
             * 4 bytes
                 * `block_cooldown`
-                * LE unsigned integer
         * If `has_pact` is set
             * 1 byte
                 * `pact_length`
-                * LE unsigned integer
                 * `pact_length` = byte_value + 1
             * `pact_length` bytes
                 * `pact`
 * 1 byte
     * `contract_count`
-    * LE unsigned integer
 * Contracts list
     * 1 byte
         * 1 bit
@@ -75,11 +76,9 @@ The domain is binary encoded. It contains a version definition, and a permission
             * Reserved
     * 32 bytes
         * `contract_address`
-        * LE unsigned integer
     * If `has_block_cooldown`
         * 4 bytes
             * `block_cooldown`
-            * LE unsigned integer
 
 ### Decode Steps
 

--- a/format.md
+++ b/format.md
@@ -13,9 +13,9 @@ Both bit and byte order are little-endian (eg, `0b10000000_00000000 = 1_u16`).
 ## Structure
 
 A doughnut contains:
-* a `version` definition
-* the version specific certificate `payload` encoding of the doughnut
-* the certificate `signature`.
+* a `VERSION` definition
+* the version specific certificate `PAYLOAD` encoding of the doughnut
+* the certificate `SIGNATURE`.
 
 ```
 <VERSION><PAYLOAD><SIGNATURE>

--- a/format.md
+++ b/format.md
@@ -42,13 +42,9 @@ To verify a doughnut:
         * How this is done depends on the payload version
     3. Verify `SIGNATURE` is valid given a message of `<VERSION><PAYLOAD>` and a signer of `ISSUER`
         * How this is done depends on the signing method
-2. Verify the user's account is the `HOLDER`
-    1. Extract the holder public key from `PAYLOAD` as `HOLDER`
-        * How this is done depends on the payload version
-    2. Verify the account attempting to use the doughnut matches the `HOLDER`
-3. Verify the payload
+2. Verify the payload
     * How this is done depends on the payload version
-4. Verify the length of the doughnut does not exceed what is inferred by the `PAYLOAD`
+3. Verify the length of the doughnut does not exceed what is inferred by the `PAYLOAD`
     * The expected length of the doughnut can be inferred by the `PAYLOAD` of the doughnut
     * Reject doughnuts which exceed their required length
     * How this is done depends on the payload version

--- a/format.md
+++ b/format.md
@@ -4,9 +4,18 @@
 
 This document outlines the format of Doughnut certificates. These are optimised for space efficiency, as we want the impact on-chain to be minimal.
 
+## Encoding
+
+A doughnut is little-endian binary encoded.
+
+Both bit and byte order are little-endian (eg, `0b10000000_00000000 = 1_u16`).
+
 ## Structure
 
-A doughnut is binary encoded. It contains a version definition, the version specific encoding of the doughnut, and the certificate signature.
+A doughnut contains:
+* a `version` definition
+* the version specific certificate `payload` encoding of the doughnut
+* the certificate `signature`.
 
 ```
 <VERSION><PAYLOAD><SIGNATURE>
@@ -25,7 +34,7 @@ The version specifies the version of the certificate payload encoding, and the s
         * LE
 
 ## Verification
-To verify a doughnut requires two steps be carried out:
+To verify a doughnut:
 
 1. Verify the issuer's signature
     1. Separate `<VERSION><PAYLOAD>` from `<SIGNATURE>`
@@ -33,7 +42,15 @@ To verify a doughnut requires two steps be carried out:
         * How this is done depends on the payload version
     3. Verify `SIGNATURE` is valid given a message of `<VERSION><PAYLOAD>` and a signer of `ISSUER`
         * How this is done depends on the signing method
-2. Verify the payload
+2. Verify the user's account is the `HOLDER`
+    1. Extract the holder public key from `PAYLOAD` as `HOLDER`
+        * How this is done depends on the payload version
+    2. Verify the account attempting to use the doughnut matches the `HOLDER`
+3. Verify the payload
+    * How this is done depends on the payload version
+4. Verify the length of the doughnut does not exceed what is inferred by the `PAYLOAD`
+    * The expected length of the doughnut can be inferred by the `PAYLOAD` of the doughnut
+    * Reject doughnuts which exceed their required length
     * How this is done depends on the payload version
 
 ## Payload
@@ -41,49 +58,40 @@ To verify a doughnut requires two steps be carried out:
 ### 0
 
 * 1 byte
-    * 1 bit  
-
+    * 1 bit
         * Indicates NotBefore timestamp inclusion when 1
-    * 2-8 bits  
-
+    * 2-8 bits
         * Permission domain count
         * Unsigned integer
-        * LE
         * To be incremented by 1 when read, shifting range from 0-127 to 1-128
 * 32 bytes
-
     * Issuer public key
-* 32 bytes  
-
+* 32 bytes
     * Holder public key
 * 4 bytes
     * Expiry, UNIX timestamp
     * Unsigned integer
-    * LE
 * If NotBefore
-    * 4 bytes  
-
+    * 4 bytes
         * NotBefore, UNIX timestamp
         * Unsigned integer
-        * LE
-* List  
-
+* List
     * Permission domain payload lengths
     * 16 bytes
         * Permission domain ID (E.g. "cennznet", a UUID, or a unique number)
     * 2 bytes
         * Length of permission domain payload in bytes
         * Unsigned integer
-        * LE
 * List
     * X bytes
         * Permission domain payload
 
-#### Verification
+#### Payload Verification
 
 To verify a v0 payload:
 1. If set, NotBefore must be less than a current unix timestamp.
 2. Expiry must be greater than a current unix timestamp.
+3. The domain list must not contain duplicate domain names.
 
 #### Notes
 ##### Permission domain list ordering


### PR DESCRIPTION
This PR addresses some clarifications identified in a recent audit of doughnut/cennznut spec.

## Addresses:

- Add verification of holder
- Add verification of permission domain payload length
- Enforce endianness (LE) at the spec level
- Do not allow Module or Method lists of 0 length

## Changes:

- Made it prettier

Doughnut Spec:
- Added requirement to verify the user account is the holder
- Added requirement to check that extra unused bytes aren't added to the end of the doughnut
- Stripped endianness out of byte descriptions and added statement that doughnuts are LE

CENNZnut Spec:
- Stripped endianness out of byte descriptions and added statement that doughnuts are LE
- `module_count` and `method_count` must start at 1
- Added note about the requirement to include contract runtime module permissions for smart contracts

## Concerns:

- None